### PR TITLE
Initial containerization and documentation

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,28 @@
+name: Build and Deploy Lammy Safety Docker Container
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-publish-worker-docker:
+    name: Lemmy Safety Container
+    runs-on: ubuntu-latest
+    steps:
+    - name: "✔️ Checkout"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+    - name: "Build and Publish Container to Github Container Registry"
+      run: |
+        docker build -t ghcr.io/db0/lemmy-safety:${{ github.ref_name }} .
+        docker push ghcr.io/db0/lemmy-safety:${{ github.ref_name }}

--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -1,0 +1,55 @@
+# Run in Container
+## Installing nvidia-container-toolkit
+In order for containers to be able to use your Nvidia GPU, the `nvidia-container-toolkit` package must be installed on the host machine. To install it, you need to import one of two repositories. If you have a deb-based distro, use this repo: `https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list`. If you have an rpm based distro, use this repo: `https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo`.
+
+More info on installing this package: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+### Install examples
+#### Ubuntu
+```
+# Import repo
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+# Install package
+sudo apt update && sudo apt install -y nvidia-container-toolkit
+```
+
+#### SUSE
+```
+# Import repo
+sudo zypper ar https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
+# Install package
+sudo zypper ref && sudo zypper install -y nvidia-container-toolkit
+```
+
+## Generate CDI specification
+After the `nvidia-container-toolkit` package has been installed, you need to create a CDI specification for the container to get all the info about your GPU.
+```
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+```
+
+## Create necessary files
+Create the db file and download the env_example file
+
+```
+mkdir lemmy-safety
+cd lemmy-safety
+touch lemmy_safety.db
+wget https://raw.githubusercontent.com/db0/lemmy-safety/main/env_example
+```
+
+Edit the env_example file that was downloaded and enter the details for your setup. Note that the ssh key path in the env file must match the right side of the volume mount. The left side must match where it is on the host.
+
+## Run the container
+Specify which script you want to run and all of the arguments you want to pass it at the end of the line
+
+### All mode, local storage example
+Local storage mode requires you to enter the passphrase of your ssh key, which means you must pass the `-it` options and must not pass the `-d` option. After entering your passphrase, you can detach your shell from the container with `Ctrl-P, Ctrl-Q`
+```
+docker run -it --rm --device nvidia.com/gpu=all --name lemmy-safety -v ./env_example:/app/.env -v ./lemmy_safety.db:/app/lemmy_safety.db -v /path/to/ssh/key/on/host.key:/app/private_key lemmy-safety:latest lemmy_safety_local_storage.py --all
+```
+
+### Daemon mode, object storage example:
+Object storage mode does not require you to interact with the container, so you can pass the `-d` option.
+```
+docker run -d --rm --device nvidia.com/gpu=all --name lemmy-safety -v ./env_example:/app/.env -v ./lemmy_safety.db:/app/lemmy_safety.db lemmy-safety:latest lemmy_safety_object_storage.py
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/python:3.10-slim-bookworm
+
+WORKDIR /app
+COPY lemmy_safety lemmy_safety
+COPY lemmy_safety_local_storage.py lemmy_safety_local_storage.py
+COPY lemmy_safety_object_storage.py lemmy_safety_object_storage.py
+COPY requirements.txt requirements.txt
+
+ENV PYTHONPATH='/app'
+RUN pip install --no-cache-dir -r requirements.txt
+ENTRYPOINT [ "python3.10" ]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,62 @@ Any potential image will be automatically deleted and its ID recorded in the DB 
 
 The daemon will then endlessly repeat this process after a 30 seconds wait.
 
+# Run in Container
+## Installing nvidia-container-toolkit
+In order for containers to be able to use your Nvidia GPU, the `nvidia-container-toolkit` package must be installed on the host machine. To install it, you need to import one of two repositories. If you have a deb-based distro, use this repo: `https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list`. If you have an rpm based distro, use this repo: `https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo`.
+
+More info on installing this package: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+### Install examples
+#### Ubuntu
+```
+# Import repo
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+# Install package
+sudo apt update && sudo apt install -y nvidia-container-toolkit
+```
+
+#### SUSE
+```
+# Import repo
+sudo zypper ar https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
+# Install package
+sudo zypper ref && sudo zypper install -y nvidia-container-toolkit
+```
+
+## Generate CDI specification
+After the `nvidia-container-toolkit` package has been installed, you need to create a CDI specification for the container to get all the info about your GPU.
+```
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+```
+
+## Create necessary files
+Create the db file and download the env_example file
+
+```
+mkdir lemmy-safety
+cd lemmy-safety
+touch lemmy_safety.db
+wget https://raw.githubusercontent.com/db0/lemmy-safety/main/env_example
+```
+
+Edit the env_example file that was downloaded and enter the details for your setup. Note that the ssh key path in the env file must match the right side of the volume mount. The left side must match where it is on the host.
+
+## Run the container
+Specify which script you want to run and all of the arguments you want to pass it at the end of the line
+
+### All mode, local storage example
+Local storage mode requires you to enter the passphrase of your ssh key, which means you must pass the `-it` options and must not pass the `-d` option. After entering your passphrase, you can detach your shell from the container with `Ctrl-P, Ctrl-Q`
+```
+docker run -it --rm --device nvidia.com/gpu=all --name lemmy-safety -v ./env_example:/app/.env -v ./lemmy_safety.db:/app/lemmy_safety.db -v /path/to/ssh/key/on/host.key:/app/private_key lemmy-safety:latest lemmy_safety_local_storage.py --all
+```
+
+### Daemon mode, object storage example:
+Object storage mode does not require you to interact with the container, so you can pass the `-d` option.
+```
+docker run -d --rm --device nvidia.com/gpu=all --name lemmy-safety -v ./env_example:/app/.env -v ./lemmy_safety.db:/app/lemmy_safety.db lemmy-safety:latest lemmy_safety_object_storage.py
+```
+
 # False positives and False negatives
 
 The script has the potential to detect wrongly of course as the clip model is not perfect.

--- a/README.md
+++ b/README.md
@@ -61,60 +61,7 @@ Any potential image will be automatically deleted and its ID recorded in the DB 
 The daemon will then endlessly repeat this process after a 30 seconds wait.
 
 # Run in Container
-## Installing nvidia-container-toolkit
-In order for containers to be able to use your Nvidia GPU, the `nvidia-container-toolkit` package must be installed on the host machine. To install it, you need to import one of two repositories. If you have a deb-based distro, use this repo: `https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list`. If you have an rpm based distro, use this repo: `https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo`.
-
-More info on installing this package: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
-
-### Install examples
-#### Ubuntu
-```
-# Import repo
-curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-# Install package
-sudo apt update && sudo apt install -y nvidia-container-toolkit
-```
-
-#### SUSE
-```
-# Import repo
-sudo zypper ar https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
-# Install package
-sudo zypper ref && sudo zypper install -y nvidia-container-toolkit
-```
-
-## Generate CDI specification
-After the `nvidia-container-toolkit` package has been installed, you need to create a CDI specification for the container to get all the info about your GPU.
-```
-sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
-```
-
-## Create necessary files
-Create the db file and download the env_example file
-
-```
-mkdir lemmy-safety
-cd lemmy-safety
-touch lemmy_safety.db
-wget https://raw.githubusercontent.com/db0/lemmy-safety/main/env_example
-```
-
-Edit the env_example file that was downloaded and enter the details for your setup. Note that the ssh key path in the env file must match the right side of the volume mount. The left side must match where it is on the host.
-
-## Run the container
-Specify which script you want to run and all of the arguments you want to pass it at the end of the line
-
-### All mode, local storage example
-Local storage mode requires you to enter the passphrase of your ssh key, which means you must pass the `-it` options and must not pass the `-d` option. After entering your passphrase, you can detach your shell from the container with `Ctrl-P, Ctrl-Q`
-```
-docker run -it --rm --device nvidia.com/gpu=all --name lemmy-safety -v ./env_example:/app/.env -v ./lemmy_safety.db:/app/lemmy_safety.db -v /path/to/ssh/key/on/host.key:/app/private_key lemmy-safety:latest lemmy_safety_local_storage.py --all
-```
-
-### Daemon mode, object storage example:
-Object storage mode does not require you to interact with the container, so you can pass the `-d` option.
-```
-docker run -d --rm --device nvidia.com/gpu=all --name lemmy-safety -v ./env_example:/app/.env -v ./lemmy_safety.db:/app/lemmy_safety.db lemmy-safety:latest lemmy_safety_object_storage.py
-```
+Please see the [dedicated instructions](CONTAINER.md)
 
 # False positives and False negatives
 


### PR DESCRIPTION
I'm not 100% certain that the --device option works with docker. I use podman and it works fine, but I can't install docker without removing the podman-compose package, as it emulates docker with podman, and that will break some other things that I have running. I think it might be more trouble than it is worth to set up a VM to test this. But someone that uses docker instead of podman might want to try that command.

I suspect that with docker you can actually omit the --device option entirely, as the CDI specification is really only needed for rootless containers (aka, podman)